### PR TITLE
check to not add java runtime arguments for 1.16.4 and 1.16.5 when using authlib-injector account 

### DIFF
--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -544,7 +544,7 @@ QStringList MinecraftInstance::processAuthArgs(AuthSessionPtr session) const
 {
     QStringList args;
 	QString v = m_components->getProfile()->getMinecraftVersion();
-	
+
     if (session->uses_custom_api_servers) {
 		if (v != "1.16.4" && v != "1.16.5") {
             args << "-Dminecraft.api.env=custom";

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -547,11 +547,11 @@ QStringList MinecraftInstance::processAuthArgs(AuthSessionPtr session) const
 	
     if (session->uses_custom_api_servers) {
 		if (v != "1.16.4" && v != "1.16.5") {
-			args << "-Dminecraft.api.env=custom";
-			args << "-Dminecraft.api.auth.host=" + session->auth_server_url;
-			args << "-Dminecraft.api.account.host=" + session->account_server_url;
-			args << "-Dminecraft.api.session.host=" + session->session_server_url;
-			args << "-Dminecraft.api.services.host=" + session->services_server_url;
+            args << "-Dminecraft.api.env=custom";
+            args << "-Dminecraft.api.auth.host=" + session->auth_server_url;
+            args << "-Dminecraft.api.account.host=" + session->account_server_url;
+            args << "-Dminecraft.api.session.host=" + session->session_server_url;
+            args << "-Dminecraft.api.services.host=" + session->services_server_url;
 		}
         auto agents = m_components->getProfile()->getAgents();
         for (auto agent : agents) {

--- a/launcher/minecraft/MinecraftInstance.cpp
+++ b/launcher/minecraft/MinecraftInstance.cpp
@@ -543,12 +543,16 @@ QString MinecraftInstance::getLauncher()
 QStringList MinecraftInstance::processAuthArgs(AuthSessionPtr session) const
 {
     QStringList args;
+	QString v = m_components->getProfile()->getMinecraftVersion();
+	
     if (session->uses_custom_api_servers) {
-        args << "-Dminecraft.api.env=custom";
-        args << "-Dminecraft.api.auth.host=" + session->auth_server_url;
-        args << "-Dminecraft.api.account.host=" + session->account_server_url;
-        args << "-Dminecraft.api.session.host=" + session->session_server_url;
-        args << "-Dminecraft.api.services.host=" + session->services_server_url;
+		if (v != "1.16.4" && v != "1.16.5") {
+			args << "-Dminecraft.api.env=custom";
+			args << "-Dminecraft.api.auth.host=" + session->auth_server_url;
+			args << "-Dminecraft.api.account.host=" + session->account_server_url;
+			args << "-Dminecraft.api.session.host=" + session->session_server_url;
+			args << "-Dminecraft.api.services.host=" + session->services_server_url;
+		}
         auto agents = m_components->getProfile()->getAgents();
         for (auto agent : agents) {
             if (agent->library()->artifactPrefix() == "moe.yushi:authlibinjector") {


### PR DESCRIPTION
<!--
Hey there! Thanks for your contribution.

Please make sure that your commits are signed off first.
If you don't know how that works, check out our contribution guidelines: https://github.com/PrismLauncher/PrismLauncher/blob/develop/CONTRIBUTING.md#signing-your-work
If you already created your commits, you can run `git rebase --signoff develop` to retroactively sign-off all your commits and `git push --force` to override what you have pushed already.

Note that signing and signing-off are two different things!
-->
